### PR TITLE
Fix query string case handling

### DIFF
--- a/src/core/router/util.js
+++ b/src/core/router/util.js
@@ -32,7 +32,7 @@ export function stringifyQuery(obj, ignores = []) {
 
     const value = obj[key];
     qs.push(
-      value !== undefined && value !== null
+      value != null
         ? `${encode(key)}=${encode(value)}`
         : encode(key)
     );

--- a/src/core/router/util.js
+++ b/src/core/router/util.js
@@ -26,13 +26,14 @@ export function stringifyQuery(obj, ignores = []) {
   const qs = [];
 
   for (const key in obj) {
-    if (ignores.indexOf(key) > -1) {
+    if (ignores.includes(key)) {
       continue;
     }
 
+    const value = obj[key];
     qs.push(
-      obj[key]
-        ? `${encode(key)}=${encode(obj[key])}`.toLowerCase()
+      value !== undefined && value !== null
+        ? `${encode(key)}=${encode(value)}`
         : encode(key)
     );
   }

--- a/test/unit/router-util.test.js
+++ b/test/unit/router-util.test.js
@@ -1,4 +1,5 @@
 const { resolvePath } = require('../../src/core/util');
+const { stringifyQuery } = require('../../src/core/router/util');
 
 // Suite
 // -----------------------------------------------------------------------------
@@ -22,6 +23,28 @@ describe('router/util', () => {
       const result = resolvePath('test/../hello.md');
 
       expect(result).toBe('/hello.md');
+    });
+  });
+
+  // stringifyQuery()
+  // ---------------------------------------------------------------------------
+  describe('stringifyQuery()', () => {
+    test('preserves case of query values', () => {
+      const result = stringifyQuery({ Foo: 'Bar' });
+
+      expect(result).toBe('?Foo=Bar');
+    });
+
+    test('ignores specified keys', () => {
+      const result = stringifyQuery({ foo: 'Bar', id: '123' }, ['id']);
+
+      expect(result).toBe('?foo=Bar');
+    });
+
+    test('handles falsy values', () => {
+      const result = stringifyQuery({ zero: 0, empty: '' });
+
+      expect(result).toBe('?zero=0&empty=');
     });
   });
 });


### PR DESCRIPTION
## Summary
- preserve case in query string creation
- cover query string behavior in tests
- handle falsy values in `stringifyQuery`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879d34d298c83309f72eda54c7768c4