### PR TITLE
Fix query string case handling

### DIFF
--- a/src/core/render/compiler.js
+++ b/src/core/render/compiler.js
@@ -8,7 +8,7 @@ import { emojify } from './emojify';
 import {
   getAndRemoveConfig,
   removeAtag,
-  getAndRemoveDocisfyIgnorConfig,
+  getAndRemoveDocsifyIgnoreConfig,
 } from './utils';
 import { imageCompiler } from './compiler/image';
 import { highlightCodeCompiler } from './compiler/code';
@@ -214,7 +214,7 @@ export class Compiler {
       const nextToc = { level, title: str };
 
       const { content, ignoreAllSubs, ignoreSubHeading } =
-        getAndRemoveDocisfyIgnorConfig(str);
+        getAndRemoveDocsifyIgnoreConfig(str);
       str = content.trim();
 
       nextToc.title = removeAtag(str);

--- a/src/core/render/compiler/headline.js
+++ b/src/core/render/compiler/headline.js
@@ -1,7 +1,7 @@
 import {
   getAndRemoveConfig,
   removeAtag,
-  getAndRemoveDocisfyIgnorConfig,
+  getAndRemoveDocsifyIgnoreConfig,
 } from '../utils';
 import { slugify } from './slugify';
 
@@ -11,7 +11,7 @@ export const headingCompiler = ({ renderer, router, _self }) =>
     const nextToc = { level, title: str };
 
     const { content, ignoreAllSubs, ignoreSubHeading } =
-      getAndRemoveDocisfyIgnorConfig(str);
+      getAndRemoveDocsifyIgnoreConfig(str);
     str = content.trim();
 
     nextToc.title = removeAtag(str);

--- a/src/core/render/utils.js
+++ b/src/core/render/utils.js
@@ -55,7 +55,7 @@ export function removeAtag(str = '') {
  *
  * @return {string}   str   The string after delete the docsifyIgnore configs.
  */
-export function getAndRemoveDocisfyIgnorConfig(content = '') {
+export function getAndRemoveDocsifyIgnoreConfig(content = '') {
   let ignoreAllSubs, ignoreSubHeading;
   if (/<!-- {docsify-ignore} -->/g.test(content)) {
     content = content.replace('<!-- {docsify-ignore} -->', '');
@@ -79,3 +79,6 @@ export function getAndRemoveDocisfyIgnorConfig(content = '') {
 
   return { content, ignoreAllSubs, ignoreSubHeading };
 }
+
+// Keep misspelled function for backward compatibility
+export const getAndRemoveDocisfyIgnorConfig = getAndRemoveDocsifyIgnoreConfig;

--- a/src/core/router/util.js
+++ b/src/core/router/util.js
@@ -26,13 +26,14 @@ export function stringifyQuery(obj, ignores = []) {
   const qs = [];
 
   for (const key in obj) {
-    if (ignores.indexOf(key) > -1) {
+    if (ignores.includes(key)) {
       continue;
     }
 
+    const value = obj[key];
     qs.push(
-      obj[key]
-        ? `${encode(key)}=${encode(obj[key])}`.toLowerCase()
+      value !== undefined && value !== null
+        ? `${encode(key)}=${encode(value)}`
         : encode(key)
     );
   }

--- a/test/unit/render-util.test.js
+++ b/test/unit/render-util.test.js
@@ -1,7 +1,7 @@
 const {
   removeAtag,
   getAndRemoveConfig,
-  getAndRemoveDocisfyIgnorConfig,
+  getAndRemoveDocsifyIgnoreConfig,
 } = require('../../src/core/render/utils');
 
 const { tree } = require(`../../src/core/render/tpl`);
@@ -21,12 +21,12 @@ describe('core/render/utils', () => {
     });
   });
 
-  // getAndRemoveDocisfyIgnorConfig()
+  // getAndRemoveDocsifyIgnoreConfig()
   // ---------------------------------------------------------------------------
-  describe('getAndRemoveDocisfyIgnorConfig()', () => {
-    test('getAndRemoveDocisfyIgnorConfig from <!-- {docsify-ignore} -->', () => {
+  describe('getAndRemoveDocsifyIgnoreConfig()', () => {
+    test('getAndRemoveDocsifyIgnoreConfig from <!-- {docsify-ignore} -->', () => {
       const { content, ignoreAllSubs, ignoreSubHeading } =
-        getAndRemoveDocisfyIgnorConfig(
+        getAndRemoveDocsifyIgnoreConfig(
           'My Ignore Title<!-- {docsify-ignore} -->'
         );
       expect(content).toBe('My Ignore Title');
@@ -34,9 +34,9 @@ describe('core/render/utils', () => {
       expect(ignoreAllSubs === undefined).toBeTruthy();
     });
 
-    test('getAndRemoveDocisfyIgnorConfig from <!-- {docsify-ignore-all} -->', () => {
+    test('getAndRemoveDocsifyIgnoreConfig from <!-- {docsify-ignore-all} -->', () => {
       const { content, ignoreAllSubs, ignoreSubHeading } =
-        getAndRemoveDocisfyIgnorConfig(
+        getAndRemoveDocsifyIgnoreConfig(
           'My Ignore Title<!-- {docsify-ignore-all} -->'
         );
       expect(content).toBe('My Ignore Title');
@@ -44,17 +44,17 @@ describe('core/render/utils', () => {
       expect(ignoreSubHeading === undefined).toBeTruthy();
     });
 
-    test('getAndRemoveDocisfyIgnorConfig from {docsify-ignore}', () => {
+    test('getAndRemoveDocsifyIgnoreConfig from {docsify-ignore}', () => {
       const { content, ignoreAllSubs, ignoreSubHeading } =
-        getAndRemoveDocisfyIgnorConfig('My Ignore Title{docsify-ignore}');
+        getAndRemoveDocsifyIgnoreConfig('My Ignore Title{docsify-ignore}');
       expect(content).toBe('My Ignore Title');
       expect(ignoreSubHeading).toBeTruthy();
       expect(ignoreAllSubs === undefined).toBeTruthy();
     });
 
-    test('getAndRemoveDocisfyIgnorConfig from {docsify-ignore-all}', () => {
+    test('getAndRemoveDocsifyIgnoreConfig from {docsify-ignore-all}', () => {
       const { content, ignoreAllSubs, ignoreSubHeading } =
-        getAndRemoveDocisfyIgnorConfig('My Ignore Title{docsify-ignore-all}');
+        getAndRemoveDocsifyIgnoreConfig('My Ignore Title{docsify-ignore-all}');
       expect(content).toBe('My Ignore Title');
       expect(ignoreAllSubs).toBeTruthy();
       expect(ignoreSubHeading === undefined).toBeTruthy();

--- a/test/unit/router-util.test.js
+++ b/test/unit/router-util.test.js
@@ -1,4 +1,5 @@
 const { resolvePath } = require('../../src/core/util');
+const { stringifyQuery } = require('../../src/core/router/util');
 
 // Suite
 // -----------------------------------------------------------------------------
@@ -22,6 +23,28 @@ describe('router/util', () => {
       const result = resolvePath('test/../hello.md');
 
       expect(result).toBe('/hello.md');
+    });
+  });
+
+  // stringifyQuery()
+  // ---------------------------------------------------------------------------
+  describe('stringifyQuery()', () => {
+    test('preserves case of query values', () => {
+      const result = stringifyQuery({ Foo: 'Bar' });
+
+      expect(result).toBe('?Foo=Bar');
+    });
+
+    test('ignores specified keys', () => {
+      const result = stringifyQuery({ foo: 'Bar', id: '123' }, ['id']);
+
+      expect(result).toBe('?foo=Bar');
+    });
+
+    test('handles falsy values', () => {
+      const result = stringifyQuery({ zero: 0, empty: '' });
+
+      expect(result).toBe('?zero=0&empty=');
     });
   });
 });


### PR DESCRIPTION
## Summary
- preserve case in query string creation
- cover query string behavior in tests
- handle falsy values in `stringifyQuery`
- correct helper function typo and keep alias for backwards compatibility

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879d34d298c83309f72eda54c7768c4